### PR TITLE
remove framework references in favour of plugins

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['mocha', 'chai', 'sinon-chai', '@angular/cli'],
+    frameworks: ['mocha', '@angular/cli'],
     plugins: [
       require('karma-mocha'),
       require('karma-chai'),


### PR DESCRIPTION
Based on the [stack overflow][so] answer, these framework references are not needed and just the plugins are fine.

[so]: http://stackoverflow.com/questions/43417343/tests-repeat-with-angular4-mocha-karma